### PR TITLE
Add variable length messages to canlib send. change rust toolchain to use latest nightly instead of old nightly to fix compilation on newer embassy versions

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2023-11-01"
+channel = "nightly"
 components = [ "rust-src", "rustfmt", "llvm-tools", "miri" ]
 targets = [
     "thumbv7em-none-eabi",

--- a/src/bin/can.rs
+++ b/src/bin/can.rs
@@ -16,7 +16,8 @@ async fn main(spawner: Spawner) {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut can=init_can(p.CAN,p.PA11,p.PA12);
+    embassy_stm32::pac::AFIO.mapr().modify(|w| w.set_can1_remap(2));
+    let mut can=init_can(p.CAN,p.PB8,p.PB9);
 
     loop {
         send_can_message(&mut can, 0x40, b"Hello world this is a test of the canbus transmission system.").await;


### PR DESCRIPTION
closes #44 
Tested
  can0  040   [8]  48 65 6C 6C 6F 20 77 6F   'Hello wo'
  can0  040   [8]  72 6C 64 20 74 68 69 73   'rld this'
  can0  040   [8]  20 69 73 20 61 20 74 65   ' is a te'
  can0  040   [8]  73 74 20 6F 66 20 74 68   'st of th'
  can0  040   [8]  65 20 63 61 6E 62 75 73   'e canbus'
  can0  040   [8]  20 74 72 61 6E 73 6D 69   ' transmi'
  can0  040   [8]  73 73 69 6F 6E 20 73 79   'ssion sy'
  can0  040   [5]  73 74 65 6D 2E            'stem.'